### PR TITLE
update openssl version to from 20.0.0 to 22.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cfn-flip==1.3.0
 cfn-lint==0.64.1
 flake8==5.0.4
 MarkupSafe==2.0.1
-pyOpenSSL==22.0.0
+pyOpenSSL==22.1.0
 pytest
 taskcat==0.9.32
 troposphere==4.1.0


### PR DESCRIPTION
Airflow deployment failed with AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms
https://github.com/tvScientific/attribution-airflow/actions/runs/3849573375/jobs/6559338203

Looks like this is caused by latest cryptography release https://cryptography.io/en/latest/changelog/#v38-0-4

requirement.txt currently installs cryptography-38.0.4 and pyOpenSSL-20.0.1

pyOpenSSL-22.1.0 min crypography requirement is 38.0.x https://pypi.org/project/pyOpenSSL/

very recent online discussions:
- https://github.com/aws/aws-sam-cli/issues/4527
- https://github.com/pyca/cryptography/issues/7959


